### PR TITLE
FEA: Add email modal for the emails/ page

### DIFF
--- a/src/react/components/common/InputGroup.tsx
+++ b/src/react/components/common/InputGroup.tsx
@@ -1,0 +1,54 @@
+import { forwardRef, type ReactNode } from 'react'
+
+export interface InputGroupProps
+  extends React.InputHTMLAttributes<HTMLInputElement> {
+  label: string
+  error?: string
+  help?: string
+  helperText?: string
+  children?: ReactNode
+}
+
+export const InputGroup = forwardRef<HTMLInputElement, InputGroupProps>(
+  (
+    { label, error, help, helperText, children, className = '', ...props },
+    ref
+  ) => {
+    const inputClasses = `
+      block w-full px-3 py-2 border rounded-md shadow-sm
+      focus:outline-none focus:ring-2 focus:ring-allauth-500 focus:border-allauth-500
+      disabled:bg-gray-100 disabled:cursor-not-allowed
+      ${
+        error
+          ? 'border-red-300 text-red-900 placeholder-red-300 focus:ring-red-500 focus:border-red-500'
+          : 'border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white'
+      }
+      ${className}
+    `.trim()
+
+    return (
+      <div className="space-y-1">
+        <div className="flex justify-between items-start">
+          <label
+            htmlFor={props.id}
+            className="block text-sm font-medium text-gray-700 dark:text-gray-300"
+          >
+            {label}
+          </label>
+          {children}
+        </div>
+        {(help || helperText) && !error && (
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            {help || helperText}
+          </p>
+        )}
+        <input ref={ref} id={props.id} className={inputClasses} {...props} />
+        {error && (
+          <p className="text-sm text-red-600 dark:text-red-400">{error}</p>
+        )}
+      </div>
+    )
+  }
+)
+
+InputGroup.displayName = 'InputGroup'

--- a/src/react/components/common/Modal.tsx
+++ b/src/react/components/common/Modal.tsx
@@ -1,0 +1,93 @@
+import type { FC, ReactNode } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
+
+export interface ModalProps {
+  open: boolean
+  onClose: () => void
+  title?: string
+  children: ReactNode
+  className?: string
+}
+
+export const Modal: FC<ModalProps> = ({
+  open,
+  onClose,
+  title,
+  children,
+  className = '',
+}) => {
+  const modalRef = useRef<HTMLDivElement>(null)
+
+  // Handle escape key
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose()
+      }
+    },
+    [onClose]
+  )
+
+  // Handle backdrop click
+  const handleBackdropClick = useCallback(
+    (e: React.MouseEvent) => {
+      if (e.target === e.currentTarget) {
+        onClose()
+      }
+    },
+    [onClose]
+  )
+
+  // Add/remove event listeners
+  useEffect(() => {
+    if (open) {
+      document.addEventListener('keydown', handleKeyDown)
+      // Prevent body scroll when modal is open
+      document.body.style.overflow = 'hidden'
+    }
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown)
+      document.body.style.overflow = ''
+    }
+  }, [open, handleKeyDown])
+
+  // Focus the modal when it opens
+  useEffect(() => {
+    if (open && modalRef.current) {
+      modalRef.current.focus()
+    }
+  }, [open])
+
+  if (!open) {
+    return null
+  }
+
+  return (
+    <div
+      className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
+      onClick={handleBackdropClick}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={title ? 'modal-title' : undefined}
+    >
+      <div
+        ref={modalRef}
+        tabIndex={-1}
+        className={`bg-white dark:bg-gray-800 rounded-lg shadow-xl max-w-md w-full mx-4 focus:outline-none ${className}`}
+      >
+        {title && (
+          <div className="px-6 py-4 border-b border-gray-200 dark:border-gray-700">
+            <h2
+              id="modal-title"
+              className="text-lg font-semibold text-gray-900 dark:text-white"
+            >
+              {title}
+            </h2>
+          </div>
+        )}
+        <div className="p-6">{children}</div>
+      </div>
+    </div>
+  )
+}

--- a/src/react/components/settings/AddEmailModal.tsx
+++ b/src/react/components/settings/AddEmailModal.tsx
@@ -1,0 +1,102 @@
+import type { FC } from 'react'
+
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useForm } from 'react-hook-form'
+import { z } from 'zod'
+
+import { useSetErrors } from '../../hooks/useSetErrors'
+import { Button } from '../common/Button'
+import { InputGroup } from '../common/InputGroup'
+import { Modal } from '../common/Modal'
+
+const schema = z.object({
+  email: z.string().email('Please enter a valid email address'),
+})
+
+type FormData = z.infer<typeof schema>
+
+export interface AddEmailModalProps {
+  open: boolean
+  onClose: () => void
+  onAdd: (email: string) => Promise<unknown> | void
+  disabled?: boolean
+}
+
+export const AddEmailModal: FC<AddEmailModalProps> = ({
+  open,
+  onClose,
+  onAdd,
+  disabled = false,
+}) => {
+  const {
+    register,
+    handleSubmit,
+    setError,
+    reset,
+    formState: { isSubmitting, errors },
+  } = useForm<FormData>({
+    resolver: zodResolver(schema),
+  })
+
+  const setErrors = useSetErrors<FormData>(setError)
+
+  const handleClose = () => {
+    reset()
+    onClose()
+  }
+
+  const onSubmit = async (data: FormData) => {
+    try {
+      const result = await onAdd(data.email)
+      // Check if result has errors (API error response)
+      if (result && typeof result === 'object' && 'errors' in result) {
+        setErrors(result as { errors?: Array<{ param?: string; message: string }> })
+        return
+      }
+      // Success - close modal and reset form
+      reset()
+      onClose()
+    } catch (e) {
+      console.error(e)
+    }
+  }
+
+  return (
+    <Modal open={open} onClose={handleClose} title="Add email address">
+      <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+        {errors?.root?.nonFieldError?.message && (
+          <div className="p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-md">
+            <p className="text-sm text-red-600 dark:text-red-400">
+              {errors.root.nonFieldError.message}
+            </p>
+          </div>
+        )}
+        <InputGroup
+          label="Email address"
+          id="add-email"
+          type="email"
+          placeholder="you@example.com"
+          error={errors?.email?.message}
+          disabled={disabled || isSubmitting}
+          autoComplete="email"
+          autoFocus
+          {...register('email')}
+        />
+        <div className="flex justify-end gap-3 pt-2">
+          <Button
+            type="button"
+            palette="gray"
+            plain
+            onClick={handleClose}
+            disabled={isSubmitting}
+          >
+            Cancel
+          </Button>
+          <Button type="submit" disabled={disabled || isSubmitting}>
+            {isSubmitting ? 'Adding...' : 'Add email'}
+          </Button>
+        </div>
+      </form>
+    </Modal>
+  )
+}

--- a/src/react/components/settings/AddEmailModal.tsx
+++ b/src/react/components/settings/AddEmailModal.tsx
@@ -18,7 +18,7 @@ type FormData = z.infer<typeof schema>
 export interface AddEmailModalProps {
   open: boolean
   onClose: () => void
-  onAdd: (email: string) => Promise<unknown> | void
+  onAdd: (email: string) => Promise<unknown> | undefined
   disabled?: boolean
 }
 
@@ -50,7 +50,9 @@ export const AddEmailModal: FC<AddEmailModalProps> = ({
       const result = await onAdd(data.email)
       // Check if result has errors (API error response)
       if (result && typeof result === 'object' && 'errors' in result) {
-        setErrors(result as { errors?: Array<{ param?: string; message: string }> })
+        setErrors(
+          result as { errors?: Array<{ param?: string; message: string }> }
+        )
         return
       }
       // Success - close modal and reset form

--- a/src/react/components/settings/EmailsTable.tsx
+++ b/src/react/components/settings/EmailsTable.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react'
 import { Button } from '../common/Button'
 import { BadgeCheck } from '../icons/BadgeCheck'
 import { ExclamationTriangle } from '../icons/ExclamationTriangle'
+import { AddEmailModal } from './AddEmailModal'
 
 interface Email {
   email: string
@@ -26,10 +27,10 @@ export const EmailsTable = ({
   makePrimary,
   verify,
   remove,
+  add,
   disabled,
 }: EmailsTableProps) => {
-  // TODO Add emails via a form in a modal component!
-  const [_open, setOpen] = useState(false)
+  const [open, setOpen] = useState(false)
 
   return (
     <div className={`px-4 sm:px-6 lg:px-8 ${className}`}>
@@ -142,6 +143,12 @@ export const EmailsTable = ({
           </div>
         </div>
       </div>
+      <AddEmailModal
+        open={open}
+        onClose={() => setOpen(false)}
+        onAdd={add}
+        disabled={disabled}
+      />
     </div>
   )
 }

--- a/src/react/index.ts
+++ b/src/react/index.ts
@@ -1,6 +1,8 @@
 export { AuthContextProvider } from './AuthContext'
 // Export components for use in consumer apps
 export { Button } from './components/common/Button'
+export { InputGroup } from './components/common/InputGroup'
+export { Modal } from './components/common/Modal'
 // Export icon components
 export { BadgeCheck } from './components/icons/BadgeCheck'
 export { Dark } from './components/icons/Dark'
@@ -9,6 +11,7 @@ export { Light } from './components/icons/Light'
 export { Logout } from './components/icons/Logout'
 export { Return } from './components/icons/Return'
 // Export settings components
+export { AddEmailModal } from './components/settings/AddEmailModal'
 export { ChangePassword } from './components/settings/ChangePassword'
 export { EmailsTable } from './components/settings/EmailsTable'
 export { EmailsTableSkeleton } from './components/settings/EmailsTableSkeleton'
@@ -28,4 +31,7 @@ export {
 } from './hooks'
 export type { AuthContextValue } from './AuthContext'
 export type { ButtonProps } from './components/common/Button'
+export type { InputGroupProps } from './components/common/InputGroup'
+export type { ModalProps } from './components/common/Modal'
+export type { AddEmailModalProps } from './components/settings/AddEmailModal'
 export type { UseUserResult } from './hooks'


### PR DESCRIPTION
## Summary
This PR adds a simple 'Add Email' modal onto the emails/ page. A user may add one email at a time.

<img width="1919" height="974" alt="image" src="https://github.com/user-attachments/assets/fa7773c6-ccdc-4194-8e2c-2ba265d271bf" />

<!-- PRs into main are released as soon as they are merged. Their descriptions will be used directly to create release notes, so make sure they contain everything! -->
<!-- Anything added between the auto-generation marker comments will be replaced on every pushed commit, so make sure to add anything you want to add outside of them. -->
<!-- However, any part of the final PR description (i.e. the description at the point of the final commit to the PR) can be changed in release notes after release if required -->
<!-- Change "START" to "SKIP" in the autogeneration marker to stop any further automatic changes to the description. ---> 

<!--- START AUTOGENERATED NOTES --->
<!--- END AUTOGENERATED NOTES --->
