### PR TITLE
FIX: Add loading prop to AuthChangeRedirector to allow loading state/loading UI to render

### DIFF
--- a/src/nextjs/routing.tsx
+++ b/src/nextjs/routing.tsx
@@ -121,6 +121,7 @@ export function AnonymousRoute({
 
 export function AuthChangeRedirector({
   children,
+  loading = null,
 }: {
   children: ReactNode
   loading?: ReactNode
@@ -136,11 +137,11 @@ export function AuthChangeRedirector({
     }
     case AUTH_CHANGE_KIND.LOGGED_IN: {
       router.push(getNext(router, urls.LOGIN_REDIRECT_URL))
-      return null
+      return loading
     }
     case AUTH_CHANGE_KIND.REAUTHENTICATED: {
       router.push(getNext(router, urls.LOGIN_REDIRECT_URL))
-      return null
+      return loading
     }
     case AUTH_CHANGE_KIND.REAUTHENTICATION_REQUIRED: {
       const next = `next=${encodeURIComponent(router.asPath)}`

--- a/src/nextjs/routing.tsx
+++ b/src/nextjs/routing.tsx
@@ -123,6 +123,7 @@ export function AuthChangeRedirector({
   children,
 }: {
   children: ReactNode
+  loading?: ReactNode
 }): ReactNode {
   const [auth, event] = useAuthChange()
   const router = useRouter()


### PR DESCRIPTION
A minor addition to `AuthChangeRedirector` that enables the UI to render properly on auth status changes.

<!-- PRs into main are released as soon as they are merged. Their descriptions will be used directly to create release notes, so make sure they contain everything! -->
<!-- Anything added between the auto-generation marker comments will be replaced on every pushed commit, so make sure to add anything you want to add outside of them. -->
<!-- However, any part of the final PR description (i.e. the description at the point of the final commit to the PR) can be changed in release notes after release if required -->
<!-- Change "START" to "SKIP" in the autogeneration marker to stop any further automatic changes to the description. ---> 

<!--- START AUTOGENERATED NOTES --->
<!--- END AUTOGENERATED NOTES --->
